### PR TITLE
Update RMF Demos security demo link

### DIFF
--- a/src/security.md
+++ b/src/security.md
@@ -15,7 +15,7 @@ corresponds to the role of that user.
  
 ![Security System Infrastructure](images/security/system_infrastructure.png)
 
-The [RMF demos][rmf_demos] repository contains an example of a 
+The [RMF Demos Office World](https://github.com/open-rmf/rmf_demos#office-world) repository contains an example of a 
 full RMF application using secured ROS 2 communications along with
 step by step explanations. 
 


### PR DESCRIPTION
Simple change to edit the text to point to Office World as the demo including the security implementation and also to update the link to the current location in open-rmf