### PR TITLE
Fix outdated and/or broken links

### DIFF
--- a/src/simulation.md
+++ b/src/simulation.md
@@ -278,9 +278,9 @@ generated for the door in the figure above is presented below.
 </model>
 ```
 
-The door [plugin](https://github.com/open-rmf/rmf_simulation/blob/6fe97895371789eb870c32db2934fbcb69f5b4c5/rmf_building_sim_common/src/door_common.cpp) responds to `DoorRequest` messages with `door_name` matching its `model name` sdf tag. These messages are published over the `/door_requests` topic. The plugin is agnostic of the type of door defined and relies on the `left_joint_name` and `right_joint_name` parameters to determine which joints to actuate during open and close motions. During these motions, the joints are commanded to their appropriate limits which are specified in the parent element. The joint motions adhere to kinematic constraints specified by sdf parameters while following acceleration and deceleration profiles similar to the `slotcar`.
+The door [plugin](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_building_sim_common/src/door_common.cpp) responds to `DoorRequest` messages with `door_name` matching its `model name` sdf tag. These messages are published over the `/door_requests` topic. The plugin is agnostic of the type of door defined and relies on the `left_joint_name` and `right_joint_name` parameters to determine which joints to actuate during open and close motions. During these motions, the joints are commanded to their appropriate limits which are specified in the parent element. The joint motions adhere to kinematic constraints specified by sdf parameters while following acceleration and deceleration profiles similar to the `slotcar`.
 
-To avoid situations where one robot requests a door to close on another robot, a `door_supervisor` [node](https://github.com/open-rmf/rmf_ros2/blob/2fe08e328f543fe6a4e0853a60607b5b52015f2a/rmf_fleet_adapter/src/door_supervisor/main.cpp) is deployed in practice. The node publishes to `/door_requests` and subscribes to `/adapter_door_requests` which the fleet adapters publish to when their robot requires access through a door. The `door_supervisor` keeps track of requests from all the fleet adapters in the system and relays the request to the door adapters while avoiding aforementioned conflicts.
+To avoid situations where one robot requests a door to close on another robot, a `door_supervisor` [node](https://github.com/open-rmf/rmf_ros2/tree/main/rmf_fleet_adapter/src/door_supervisor) is deployed in practice. The node publishes to `/door_requests` and subscribes to `/adapter_door_requests` which the fleet adapters publish to when their robot requires access through a door. The `door_supervisor` keeps track of requests from all the fleet adapters in the system and relays the request to the door adapters while avoiding aforementioned conflicts.
 
 ### Lifts
 The ability to test lift integration is crucial as these systems are often the operational bottlenecks in facilities given their shared usage by both humans and multi robot fleets. As with annotated doors, lifts can be customized in a number of ways in the `traffic_editor` GUI including the dimension & orientation of the cabin and mapping cabin doors to building levels.
@@ -322,7 +322,7 @@ The plugin subscribes to `/lift_requests` topic and responds to `LiftRequest` me
 The displacement between the cabin's current elevation and that of the `destination_floor` is computed and a suitable velocity is applied to the cabin joint.
 Prior to any motion, the cabin doors are closed and only opened at the `destination_floor` if specified in the `LiftRequest` message.
 As the cabin and shaft doors are configured with the `door` plugin, they are commanded through `DoorRequest` messages published by the `lift` plugin.
-Analogous to the `door_supervisor`, a `lift_supervisor` [node](https://github.com/open-rmf/rmf_ros2/blob/2fe08e328f543fe6a4e0853a60607b5b52015f2a/rmf_fleet_adapter/src/lift_supervisor/main.cpp) is started in practice to manage requests from different robot fleets.
+Analogous to the `door_supervisor`, a `lift_supervisor` [node](https://github.com/open-rmf/rmf_ros2/tree/main/rmf_fleet_adapter/src/lift_supervisor) is started in practice to manage requests from different robot fleets.
 
 ### Workcells
 
@@ -343,11 +343,11 @@ To setup a payload unloading station in simulation:
 
 When a `DispenserRequest` message is published with `target_guid` matching the
 name of the `TeleportDispenser` model, the plugin will teleport the payload onto
-the nearest robot model. Conversely, when an `IngestorRequest` message is published 
+the nearest robot model. Conversely, when an `IngestorRequest` message is published
 with the `target_guid` matching the name of the `TeleportIngestor` model, the
-`TeleportIngestor` plugin will teleport the payload from the robot to its location in 
-the world. The combinations of these plugins allow delivery requests to be simulated. 
-In the future, these mechanisms will be replaced by actual workcells or robot arms 
+`TeleportIngestor` plugin will teleport the payload from the robot to its location in
+the world. The combinations of these plugins allow delivery requests to be simulated.
+In the future, these mechanisms will be replaced by actual workcells or robot arms
 but the underlying message exchanges will remain the same.
 
 ![TeleportDispenser and TeleportIngestor models](images/dispensers.png)
@@ -355,7 +355,7 @@ but the underlying message exchanges will remain the same.
 ### Crowdsim
 
 Crowd Simulation, aka `CrowdSim` is an optional feature in RMF simulation. User can
-choose to enable crowdsim on `rmf_traffic_editor`. In RMF, the crowdsim plugin uses 
+choose to enable crowdsim on `rmf_traffic_editor`. In RMF, the crowdsim plugin uses
 [menge](https://github.com/open-rmf/menge_vendor) as the core to control each of
 simulated agent in the world.
 
@@ -364,7 +364,7 @@ An example of crowdsim is demonstrated on rmf_demos's `airport_world`:
 ros2 launch rmf_demos_gz airport_terminal.launch.xml use_crowdsim:=1
 ```
 
-For more details on how `crowdsim` works and how to configure it, 
+For more details on how `crowdsim` works and how to configure it,
 please dive in to [the detailed guide for using Crowdsim](https://github.com/FloodShao/crowd_simulation/blob/master/crowd_simulation_doc/crowd_simulation_usage.md).
 
 ![crowdsim example](images/airport_crowdsim.png)
@@ -446,9 +446,9 @@ The `rmf_demos` package includes all the essential launch files required to brin
 ```
 
 
-To launch a simulated world in gazebo, a snippet from [rmf_demos_gz](https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_gz) 
-is shown below. Similarly, user can also choose to run with ignition 
-simulator, [rmf_demos_ign](https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_ign) 
+To launch a simulated world in gazebo, a snippet from [rmf_demos_gz](https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_gz)
+is shown below. Similarly, user can also choose to run with ignition
+simulator, [rmf_demos_ign](https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_ign)
 
 ```xml
   <group>

--- a/src/simulation.md
+++ b/src/simulation.md
@@ -161,7 +161,7 @@ open sourced for use in simulation. For these models to emulate the behavior of
 their physical counterparts which have been integrated with RMF, they need to 1)
 interface with `rmf_fleet_adapters` and 2) navigate to locations in the
 simulated world. These functionalities, for a "_full control_" robot type, are
-achieved through the `slotcar` [plugin](https://github.com/osrf/traffic_editor/blob/master/building_gazebo_plugins/src/slotcar.cpp).
+achieved through the `slotcar` [plugin](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_robot_sim_gazebo_plugins/src/slotcar.cpp).
 The plugin subscribes to `/robot_path_requests` and `/robot_mode_requests`
 topics and responds to relevant `PathRequest` and `ModeRequest` messages
 published by its `rmf_fleet_adapter`. The plugin also publishes the robot's
@@ -278,9 +278,9 @@ generated for the door in the figure above is presented below.
 </model>
 ```
 
-The door [plugin](https://github.com/osrf/traffic_editor/blob/master/building_gazebo_plugins/src/door.cpp) responds to `DoorRequest` messages with `door_name` matching its `model name` sdf tag. These messages are published over the `/door_requests` topic. The plugin is agnostic of the type of door defined and relies on the `left_joint_name` and `right_joint_name` parameters to determine which joints to actuate during open and close motions. During these motions, the joints are commanded to their appropriate limits which are specified in the parent element. The joint motions adhere to kinematic constraints specified by sdf parameters while following acceleration and deceleration profiles similar to the `slotcar`.
+The door [plugin](https://github.com/open-rmf/rmf_simulation/blob/6fe97895371789eb870c32db2934fbcb69f5b4c5/rmf_building_sim_common/src/door_common.cpp) responds to `DoorRequest` messages with `door_name` matching its `model name` sdf tag. These messages are published over the `/door_requests` topic. The plugin is agnostic of the type of door defined and relies on the `left_joint_name` and `right_joint_name` parameters to determine which joints to actuate during open and close motions. During these motions, the joints are commanded to their appropriate limits which are specified in the parent element. The joint motions adhere to kinematic constraints specified by sdf parameters while following acceleration and deceleration profiles similar to the `slotcar`.
 
-To avoid situations where one robot requests a door to close on another robot, a `door_supervisor` [node](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_adapter/src/door_supervisor/main.cpp) is deployed in practice. The node publishes to `/door_requests` and subscribes to `/adapter_door_requests` which the fleet adapters publish to when their robot requires access through a door. The `door_supervisor` keeps track of requests from all the fleet adapters in the system and relays the request to the door adapters while avoiding aforementioned conflicts.
+To avoid situations where one robot requests a door to close on another robot, a `door_supervisor` [node](https://github.com/open-rmf/rmf_ros2/blob/2fe08e328f543fe6a4e0853a60607b5b52015f2a/rmf_fleet_adapter/src/door_supervisor/main.cpp) is deployed in practice. The node publishes to `/door_requests` and subscribes to `/adapter_door_requests` which the fleet adapters publish to when their robot requires access through a door. The `door_supervisor` keeps track of requests from all the fleet adapters in the system and relays the request to the door adapters while avoiding aforementioned conflicts.
 
 ### Lifts
 The ability to test lift integration is crucial as these systems are often the operational bottlenecks in facilities given their shared usage by both humans and multi robot fleets. As with annotated doors, lifts can be customized in a number of ways in the `traffic_editor` GUI including the dimension & orientation of the cabin and mapping cabin doors to building levels.
@@ -322,7 +322,7 @@ The plugin subscribes to `/lift_requests` topic and responds to `LiftRequest` me
 The displacement between the cabin's current elevation and that of the `destination_floor` is computed and a suitable velocity is applied to the cabin joint.
 Prior to any motion, the cabin doors are closed and only opened at the `destination_floor` if specified in the `LiftRequest` message.
 As the cabin and shaft doors are configured with the `door` plugin, they are commanded through `DoorRequest` messages published by the `lift` plugin.
-Analogous to the `door_supervisor`, a `lift_supervisor` [node](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_adapter/src/lift_supervisor/main.cpp) is started in practice to manage requests from different robot fleets.
+Analogous to the `door_supervisor`, a `lift_supervisor` [node](https://github.com/open-rmf/rmf_ros2/blob/2fe08e328f543fe6a4e0853a60607b5b52015f2a/rmf_fleet_adapter/src/lift_supervisor/main.cpp) is started in practice to manage requests from different robot fleets.
 
 ### Workcells
 
@@ -330,8 +330,8 @@ A common use case is robots performing deliveries within facilities, so a `Deliv
 In a delivery task, a payload is loaded onto the robot at one location (pickup waypoint) and unloaded at another (dropoff waypoint).
 The loading and unloading of the payload onto and from a robot may be automated by robots/workcells in the facility. These devices are henceforth referred to as dispensers and ingestors respectively.
 
-To replicate the loading and unloading processes in simulation, the `TeleportDispenser` and `TeleportIngestor` [plugins](https://github.com/osrf/rmf_demos/tree/master/rmf_gazebo_plugins/src) have been designed.
-These plugins are attached to the `TeleportDispenser` and `TeleportIngestor` [3D models](https://github.com/osrf/rmf_demos/tree/master/rmf_demos_assets/models), respectively.
+To replicate the loading and unloading processes in simulation, the `TeleportDispenser` and `TeleportIngestor` [plugins](https://github.com/open-rmf/rmf_simulation/tree/main/rmf_robot_sim_gazebo_plugins/src) have been designed.
+These plugins are attached to the `TeleportDispenser` and `TeleportIngestor` [3D models](https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_assets/models), respectively.
 To setup a payload loading station in simulation:
 * Add a `TeleportDispenser` model beside the pickup waypoint and assign it a
   unique `name`
@@ -372,7 +372,7 @@ please dive in to [the detailed guide for using Crowdsim](https://github.com/Flo
 ---
 
 ## Creating Simulations and Running Scenarios
-The section aims to provide an overview of the various components in the `rmf_demos` [repository](https://github.com/osrf/rmf_demos) which may serve as a reference for setting up other simulations and assigning tasks to robots. Here, we will focus on the `office` world.
+The section aims to provide an overview of the various components in the `rmf_demos` [repository](https://github.com/open-rmf/rmf_demos) which may serve as a reference for setting up other simulations and assigning tasks to robots. Here, we will focus on the `office` world.
 
 ### Map package
 The `rmf_demos_maps` package houses annotated `traffic_editor` files which will be used for the 3D world generation. Opening the `office.project.yaml` file in `traffic_editor` reveals a single level floorplan that has walls, floors, scale measurements, doors, lanes and models annotated. All the robot lanes are set to `bidirectional` with `graph_idx` equal to "0". The latter signifies that all the lanes belong to the same fleet. In the `airport` world, we have two sets of graphs with indices "0" and "1" which reflect laneways occupiable by two fleets respectively. The figure below highlights properties assigned to a lane and a waypoint that serves as a robot spawn location.


### PR DESCRIPTION
Updated links to point to the open-rmf repository. would appreciate a double check that the new links are all correct as some terminology seems to have changed. 

One specific item is the door plugin link:

OLD: https://github.com/osrf/traffic_editor/blob/master/building_gazebo_plugins/src/door.cpp

PROPOSED NEW: https://github.com/open-rmf/rmf_simulation/blob/6fe97895371789eb870c32db2934fbcb69f5b4c5/rmf_building_sim_common/src/door_common.cpp