### PR TITLE
Update outdated link

### DIFF
--- a/src/integration_fleets.md
+++ b/src/integration_fleets.md
@@ -10,7 +10,7 @@ Before such a fleet can be integrated, you will need to procure or produce a rou
 
 ## C++ API
 
-The C++ API for **Full Control** automated guided vehicle (AGV) fleets can be found in the [`rmf_fleet_adapter`](https://github.com/osrf/rmf_core/tree/master/rmf_fleet_adapter/include/rmf_fleet_adapter/agv) package of the `rmf_core` repo. The API consists of four critical classes:
+The C++ API for **Full Control** automated guided vehicle (AGV) fleets can be found in the [`rmf_fleet_adapter`](https://github.com/open-rmf/rmf_ros2/tree/main/rmf_fleet_adapter) package of the `rmf_ros2` repo. The API consists of four critical classes:
 
 * [`Adapter`](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp) - Initializes and maintains communication with the other core RMF systems. Use this to register one or more fleets and receive a `FleetUpdateHandle` for each fleet.
 * [`FleetUpdateHandle`](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp) - Allows you to configure a fleet by adding robots and specifying settings for the fleet (e.g. specifying what types of deliveries the fleet can perform). New robots can be added to the fleet at any time.


### PR DESCRIPTION
updated rmf_fleet_adapter link to point to the open-rmf org and change `rmf_core` repo to `rmf_ros2`. Would like someone to double check this one