### PR TITLE
Update ubuntu version

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,9 +1,6 @@
 name: github pages
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   deploy:


### PR DESCRIPTION
The book is currently deployed on an Ubuntu 18.04 machine (glibc 2.27) which raises the following error since the latest version of mdbook requires glibc 2.29:
```
mdbook: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by mdbook)
```
and the book doesn't compile accordingly. This PR uses Ubuntu 20.04 (glibc 2.31) for deployment instead.