### PR TITLE
Github Workflow Fix

### DIFF
--- a/.github/workflows/dev.workflow.yml
+++ b/.github/workflows/dev.workflow.yml
@@ -1,7 +1,10 @@
-name: github pages
+name: Dev Workflow 
 
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - master
+      
 jobs:
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/prod.workflow.yml
+++ b/.github/workflows/prod.workflow.yml
@@ -1,0 +1,18 @@
+name: Master Workflow 
+
+on:  pull_request
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: 'latest'
+
+      - run: cargo install mdbook-open-on-gh
+      - run: mdbook build
+


### PR DESCRIPTION
Solves the issue of GitHub actions running when there is a pull request.
Adds following features
- [X] Different files for `push` and `pull_request`
- [X] `pull_request` will not run the the deploy script
- [X] `push` will deploy only if the branch is `master`
