### PR TITLE
Added How-to Guides section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -20,7 +20,6 @@
 - [SOSS](./soss.md)
 - [Integration](./integration.md)
   - [Navigation Maps](./integration_nav-maps.md)
-    - [Graph Strategies](./integration_nav-maps-strategies.md)
   - [Mobile Robot Fleets](./integration_fleets.md)
     - [Fleet Adapter Tutorial](./integration_fleets_adapter_tutorial.md)
     - [PerformAction Tutorial](./integration_fleets_action_tutorial.md)
@@ -35,3 +34,4 @@
 - [Security](./security.md)
 - [Roadmap](./roadmap.md)
 - [How-to Guides](./howto_guides.md)
+  - [Graph Strategies](./integration_nav-maps-strategies.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -34,3 +34,4 @@
   - [User Interfaces](./ui.md)
 - [Security](./security.md)
 - [Roadmap](./roadmap.md)
+- [How-to Guides](./howto_guides.md)

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -4,5 +4,5 @@ How-to Guides provide direct and modular answers to “How-to” questions regar
 
 They contain step-by-step instructions you can follow to quickly get started with key aspects of Open-RMF that are not covered in previous sections.
 
-If there are any interesting topics you would like to **contribute**, **feel free to open a Pull Request [here](https://github.com/osrf/ros2multirobotbook)**.
+If there are any interesting topics you would like to contribute, feel free to open a Pull Request [here](https://github.com/osrf/ros2multirobotbook).
 

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -1,6 +1,6 @@
 # Introduction
 
-How-to Guides provide direct and modular answers to “How-to” questions regarding specific topics or questions you may have in Open-RMF. 
+How-to Guides provide direct and modular answers to “How-to” questions regarding specific topics you may have about Open-RMF. 
 
 They contain step by step instructions you can follow to quickly get started with key aspects of Open-RMF which is otherwise not covered in previous sections.
 

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -4,5 +4,5 @@ How-to Guides provide direct and modular answers to “How-to” questions regar
 
 They contain step-by-step instructions you can follow to quickly get started with key aspects of Open-RMF that are not covered in previous sections.
 
-If there are any interesting topics you will like to **contribute**, **feel free to open a Pull Request [here](https://github.com/osrf/ros2multirobotbook)**.
+If there are any interesting topics you would like to **contribute**, **feel free to open a Pull Request [here](https://github.com/osrf/ros2multirobotbook)**.
 

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -1,8 +1,8 @@
 # Introduction
 
-How-to Guides provide **direct and modular answers** to “How-to” questions regarding **specific topics or questions** you may have in Open-RMF. 
+How-to Guides provide direct and modular answers to “How-to” questions regarding specific topics or questions you may have in Open-RMF. 
 
-They contain **step by step instructions** you can follow to quickly get started with key aspects of Open-RMF which is otherwise not covered in previous sections.
+They contain step by step instructions you can follow to quickly get started with key aspects of Open-RMF which is otherwise not covered in previous sections.
 
-If there are any interesting topics you will like to **contribute to the wider Open-RMF community**, **feel free to write up an article and share it here through a Pull Request**.
+If there are any interesting topics you will like to contribute to the wider Open-RMF community, feel free to write up an article and share it here through a Pull Request.
 

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -2,7 +2,7 @@
 
 How-to Guides provide direct and modular answers to “How-to” questions regarding specific topics you may have about Open-RMF. 
 
-They contain step by step instructions you can follow to quickly get started with key aspects of Open-RMF which is otherwise not covered in previous sections.
+They contain step-by-step instructions you can follow to quickly get started with key aspects of Open-RMF that are not covered in previous sections.
 
 If there are any interesting topics you will like to contribute to the wider Open-RMF community, feel free to write up an article and share it here through a Pull Request.
 

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -4,5 +4,5 @@ How-to Guides provide direct and modular answers to “How-to” questions regar
 
 They contain step-by-step instructions you can follow to quickly get started with key aspects of Open-RMF that are not covered in previous sections.
 
-If there are any interesting topics you will like to contribute to the wider Open-RMF community, feel free to write up an article and share it here through a Pull Request.
+If there are any interesting topics you will like to **contribute**, **feel free to open a Pull Request [here](https://github.com/osrf/ros2multirobotbook)**.
 

--- a/src/howto_guides.md
+++ b/src/howto_guides.md
@@ -1,0 +1,8 @@
+# Introduction
+
+How-to Guides provide **direct and modular answers** to “How-to” questions regarding **specific topics or questions** you may have in Open-RMF. 
+
+They contain **step by step instructions** you can follow to quickly get started with key aspects of Open-RMF which is otherwise not covered in previous sections.
+
+If there are any interesting topics you will like to **contribute to the wider Open-RMF community**, **feel free to write up an article and share it here through a Pull Request**.
+


### PR DESCRIPTION
## **Purpose of Pull Request** :bookmark: 
This Pull Request (PR) is aimed at appending a new catch-all section called `How-to Guides`, addressing the suggestion brought in in #120. 

Details are covered in the aforementioned issue thread.

## **Summary of Edits** :books: 
- Added new section under `SUMMARY.md`.
- Created a new `.md` document, `howto_guides.md` with a short introduction on what the section is all about.

## **Remarks** :speech_balloon: 
To set a proper example of what is a good how-to guide, I will write up a article to be added under the new `How-to Guides` section within the coming weeks.